### PR TITLE
Add missing resp.Close() to HTTP response handling

### DIFF
--- a/bse/bse.go
+++ b/bse/bse.go
@@ -84,7 +84,9 @@ func (s *BSE) getRealtime() *BSE {
 	if err != nil {
 		log.Println("Failed to get bse realtime:", err)
 		return s
-	} else if resp.StatusCode != 200 {
+	}
+	defer resp.Close()
+	if resp.StatusCode != 200 {
 		log.Println("Bad status code:", resp.StatusCode)
 		return s
 	}
@@ -138,7 +140,9 @@ func (s *BSE) getChart() *BSE {
 	if err != nil {
 		log.Println("Failed to get bse chart:", err)
 		return s
-	} else if resp.StatusCode != 200 {
+	}
+	defer resp.Close()
+	if resp.StatusCode != 200 {
 		log.Println("Bad status code:", resp.StatusCode)
 		return s
 	}
@@ -182,7 +186,9 @@ func Suggests(keyword string) (suggests []stock.Suggest) {
 	if err != nil {
 		log.Println("Failed to get bse suggest:", err)
 		return
-	} else if resp.StatusCode != 200 {
+	}
+	defer resp.Close()
+	if resp.StatusCode != 200 {
 		log.Println("Bad status code:", resp.StatusCode)
 		return
 	}

--- a/capitalflows/capitalflows.go
+++ b/capitalflows/capitalflows.go
@@ -26,6 +26,7 @@ func Fetch() (cf CapitalFlows, err error) {
 	if err != nil {
 		return
 	}
+	defer resp.Close()
 	if resp.StatusCode != 200 {
 		err = fmt.Errorf("status code: %d", resp.StatusCode)
 		return

--- a/eastmoney/eastmoney.go
+++ b/eastmoney/eastmoney.go
@@ -89,7 +89,9 @@ func (s *EastMoney) getRealtime() *EastMoney {
 	if err != nil {
 		log.Println("Failed to get eastmoney realtime:", err)
 		return s
-	} else if resp.StatusCode != 200 {
+	}
+	defer resp.Close()
+	if resp.StatusCode != 200 {
 		log.Println("Bad status code:", resp.StatusCode)
 		return s
 	}
@@ -148,7 +150,9 @@ func (s *EastMoney) getChart() *EastMoney {
 	if err != nil {
 		log.Println("Failed to get eastmoney chart:", err)
 		return s
-	} else if resp.StatusCode != 200 {
+	}
+	defer resp.Close()
+	if resp.StatusCode != 200 {
 		log.Println("Bad status code:", resp.StatusCode)
 		return s
 	}
@@ -195,7 +199,9 @@ func Suggests(keyword string) (suggests []stock.Suggest) {
 	if err != nil {
 		log.Println("Failed to get eastmoney suggest:", err)
 		return
-	} else if resp.StatusCode != 200 {
+	}
+	defer resp.Close()
+	if resp.StatusCode != 200 {
 		log.Println("Bad status code:", resp.StatusCode)
 		return
 	}

--- a/sse/sse.go
+++ b/sse/sse.go
@@ -44,7 +44,9 @@ func (s *SSE) getRealtime() *SSE {
 	if err != nil {
 		log.Println("Failed to get sse realtime:", err)
 		return s
-	} else if resp.StatusCode != 200 {
+	}
+	defer resp.Close()
+	if resp.StatusCode != 200 {
 		log.Println("Bad status code:", resp.StatusCode)
 		return s
 	}
@@ -97,7 +99,9 @@ func (s *SSE) getChart() *SSE {
 	if err != nil {
 		log.Println("Failed to get sse chart:", err)
 		return s
-	} else if resp.StatusCode != 200 {
+	}
+	defer resp.Close()
+	if resp.StatusCode != 200 {
 		log.Println("Bad status code:", resp.StatusCode)
 		return s
 	}

--- a/szse/szse.go
+++ b/szse/szse.go
@@ -52,7 +52,9 @@ func (s *SZSE) get() *SZSE {
 	if err != nil {
 		log.Println("Failed to get szse:", err)
 		return s
-	} else if resp.StatusCode != 200 {
+	}
+	defer resp.Close()
+	if resp.StatusCode != 200 {
 		log.Println("Bad status code:", resp.StatusCode)
 		return s
 	}
@@ -115,7 +117,9 @@ func Suggests(keyword string) (suggests []stock.Suggest) {
 	if err != nil {
 		log.Println("Failed to get szse suggest:", err)
 		return
-	} else if resp.StatusCode != 200 {
+	}
+	defer resp.Close()
+	if resp.StatusCode != 200 {
 		log.Println("Bad status code:", resp.StatusCode)
 		return
 	}

--- a/txzq/txzq.go
+++ b/txzq/txzq.go
@@ -45,7 +45,9 @@ func (s *TXZQ) get() *TXZQ {
 	if err != nil {
 		log.Println("Failed to get txzq:", err)
 		return s
-	} else if resp.StatusCode != 200 {
+	}
+	defer resp.Close()
+	if resp.StatusCode != 200 {
 		log.Println("Bad status code:", resp.StatusCode)
 		return s
 	}
@@ -132,7 +134,9 @@ func Suggests(keyword string) (suggests []stock.Suggest) {
 		if err != nil {
 			log.Println("Failed to get txzq suggest:", err)
 			continue
-		} else if resp.StatusCode != 200 {
+		}
+		defer resp.Close()
+		if resp.StatusCode != 200 {
 			log.Println("Bad status code:", resp.StatusCode)
 			continue
 		}


### PR DESCRIPTION
Ensures all HTTP responses are properly closed after use in bse, capitalflows, eastmoney, sse, szse, and txzq modules. This prevents potential resource leaks by adding defer resp.Close() after successful HTTP requests.